### PR TITLE
Add support for Mode5 view (40x12)

### DIFF
--- a/AtariView.cs
+++ b/AtariView.cs
@@ -4,6 +4,7 @@
 	{
 		public const int VIEW_WIDTH = 40;
 		public const int VIEW_HEIGHT = 26;
+		public const int VIEW_HEIGHT_TALL = 13;
 
 		#region Data
 

--- a/AtariViewEditor.cs
+++ b/AtariViewEditor.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.VisualBasic;
 using System;
 using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
 using System.Text;
+using System.Windows.Forms;
 using TinyJson;
 
 namespace FontMaker
@@ -377,8 +379,10 @@ namespace FontMaker
 			var colorOffset = InColorMode ? 512 : 0;
 			var img = Helpers.GetImage(pictureBoxAtariView);
 			using (var gr = Graphics.FromImage(img))
-			{
-				gr.InterpolationMode = InterpolationMode.NearestNeighbor;
+            using (ImageAttributes wrapMode = new ImageAttributes())
+            {
+                wrapMode.SetWrapMode(WrapMode.TileFlipXY);
+                gr.InterpolationMode = InterpolationMode.NearestNeighbor;
 				gr.Clear(AtariPalette[SetOfSelectedColors[1]]);
 
 				var destRect = new Rectangle
@@ -406,7 +410,7 @@ namespace FontMaker
 						srcRect.X = rx * 16;
 						srcRect.Y = ry * 16 + Constants.FontYOffset[AtariView.UseFontOnLine[y] - 1] + colorOffset;
 
-						gr.DrawImage(AtariFontRenderer.BitmapFontBanks, destRect, srcRect, GraphicsUnit.Pixel);
+						gr.DrawImage(AtariFontRenderer.BitmapFontBanks, destRect, srcRect.Left, srcRect.Top, srcRect.Width, srcRect.Height, GraphicsUnit.Pixel, wrapMode);
 					}
 				}
 			}
@@ -423,7 +427,9 @@ namespace FontMaker
 			var img = Helpers.GetImage(pictureBoxAtariView);
 			
 			using (var gr = Graphics.FromImage(img))
-			{
+            using (ImageAttributes wrapMode = new ImageAttributes())
+            {
+                wrapMode.SetWrapMode(WrapMode.TileFlipXY);
                 gr.InterpolationMode = InterpolationMode.NearestNeighbor;
                 var destRect = new Rectangle
 				{
@@ -466,19 +472,20 @@ namespace FontMaker
 						{
 							srcRect.Y = ry * 16 + fontYOffset;
 							//gr.DrawImage(pictureBoxFontSelector.Image, destRect, srcRect, GraphicsUnit.Pixel);
-							gr.DrawImage(AtariFontRenderer.BitmapFontBanks, destRect, srcRect, GraphicsUnit.Pixel);
+                            gr.DrawImage(AtariFontRenderer.BitmapFontBanks, destRect, srcRect.Left, srcRect.Top, srcRect.Width, srcRect.Height, GraphicsUnit.Pixel, wrapMode);
 
-						}
+                        }
 
-						if (AtariView.ViewBytes[x, y] == (byte)dp)
+                        if (AtariView.ViewBytes[x, y] == (byte)dp)
 						{
 							srcRect.Y = ny * 16 + fontYOffset;
 							//gr.DrawImage(pictureBoxFontSelector.Image, destRect, srcRect, GraphicsUnit.Pixel);
 							
 		
-							gr.DrawImage(AtariFontRenderer.BitmapFontBanks, destRect, srcRect, GraphicsUnit.Pixel);
-						}
-					}
+                            gr.DrawImage(AtariFontRenderer.BitmapFontBanks, destRect, srcRect.Left, srcRect.Top, srcRect.Width, srcRect.Height, GraphicsUnit.Pixel, wrapMode);
+
+                        }
+                    }
 				}
 			}
 

--- a/Colors.cs
+++ b/Colors.cs
@@ -38,7 +38,25 @@ namespace FontMaker
 
 		private void SwitchGfxMode()
 		{
-			InColorMode = !InColorMode;
+			// Switch to tall color mode and return
+			if (InColorMode && !InTallMode)
+			{
+				InTallMode = true;
+				RedrawLineTypes();
+                RedrawView();
+				RedrawChar();
+				return;
+			} 
+
+			if (InTallMode)
+			{
+                InTallMode = false;
+                RedrawLineTypes();
+            }
+
+            
+            InColorMode = !InColorMode;
+			
 			ShowCorrectFontBank();
 			RedrawView();
 
@@ -348,6 +366,9 @@ namespace FontMaker
 				BrushCache[i]?.Dispose();
 				BrushCache[i] = new SolidBrush(AtariPalette[SetOfSelectedColors[i]]);
 			}
+
+			if (EmptyBrush == null)
+				EmptyBrush = new SolidBrush(Color.FromKnownColor(KnownColor.DarkGray));
 
 			AtariFontRenderer.RebuildPalette(SetOfSelectedColors);
 		}

--- a/FontMakerForm.cs
+++ b/FontMakerForm.cs
@@ -71,7 +71,25 @@ namespace FontMaker
 		/// </summary>
 		internal Color[] AtariPalette { get; set; } = new Color[256];
 		internal bool InColorMode { get; set; } = false;
-		internal int ActiveColorNr { get; set; }
+		private bool _inTallMode = false;
+        internal bool InTallMode { get { return _inTallMode; } 
+			set
+			{
+				_inTallMode = value;
+				CellHeight = _inTallMode ? 32 : 16;
+				CursorHeight = _inTallMode ? 40 : 20;
+				CharXWidth = _inTallMode ? 20 : 40;
+				ViewHeight = _inTallMode ? AtariView.VIEW_HEIGHT_TALL : AtariView.VIEW_HEIGHT;
+			} 
+		}
+
+		internal int CellHeight { get; set; } = 16;
+		internal int CursorHeight { get; set; } = 20;
+		internal int CharXWidth { get; set; } = 40;
+		internal int ViewHeight { get; set; } = AtariView.VIEW_HEIGHT;
+
+		internal bool PastingToView { get; set; }
+        internal int ActiveColorNr { get; set; }
 		/// <summary>
 		/// The 6 active colors: These are indexes into the Atari color palette
 		/// 2 for mono (index 0 + 1)
@@ -79,7 +97,7 @@ namespace FontMaker
 		/// </summary>
 		internal byte[] SetOfSelectedColors { get; set; } = new byte[6];
 		internal SolidBrush[] BrushCache { get; set; } = new SolidBrush[6];
-
+		internal SolidBrush EmptyBrush { get; set; }
 
 		internal string CurrentDataFolder { get; set; } = string.Empty;
 		internal string Font1Filename { get; set; } = string.Empty;

--- a/FontSelector.cs
+++ b/FontSelector.cs
@@ -322,8 +322,14 @@ namespace FontMaker
 								pictureBoxFontSelectorMegaCopyImage.Visible = false;
 								return;
 							}
+                            
+							if (PastingToView)
+                            {
+                                PastingToView = false;
+                                RevalidateClipboard();
+                            }
 
-							pictureBoxFontSelectorPasteCursor.Left = pictureBoxFontSelector.Left + e.X - e.X % 16 - 2;
+                            pictureBoxFontSelectorPasteCursor.Left = pictureBoxFontSelector.Left + e.X - e.X % 16 - 2;
 							pictureBoxFontSelectorPasteCursor.Top = pictureBoxFontSelector.Top + e.Y - e.Y % 16 - 2;
 							pictureBoxFontSelectorMegaCopyImage.Left = pictureBoxFontSelectorPasteCursor.Left + 2;
 							pictureBoxFontSelectorMegaCopyImage.Top = pictureBoxFontSelectorPasteCursor.Top + 2;


### PR DESCRIPTION
I've really enjoyed this tool the past few years and recently have a project in MODE5 (40x12) and really wanted to see the proper aspect ratio of the view, so I modifed the code to add support for MODE5.

Clicking "Change GFX" now switches between Mode 0, 4, and 5.

It basically draws each character twice as high in the view, resulting in showing the first 13 rows of the view.

Changes:

- Save/Restore of view remembers the new mode ``"ColoredGfx": "2"``
- View switches to 13 rows instead of 26
- Font selection on the view row spaced to 13 rows
- Cursor and Mega copy shows correct aspect ratio in view
- Character editor shows correct aspect ratio

<img width="1176" alt="Screenshot 2024-11-24 at 12 23 53 PM" src="https://github.com/user-attachments/assets/a22eb598-b771-4faf-8ba1-04575c83f2c7">

MINOR NOTE: I made the edits in Visual Studio 2022 on Windows in parallels desktop on my Mac. I see some slight space/tab differences when looking at the files in my mac and here in github vs the "windows vs studio". I'm guessing because VS normally converts tabs to spaces.